### PR TITLE
fix download path and check filesize

### DIFF
--- a/inference.py
+++ b/inference.py
@@ -73,11 +73,17 @@ def main():
             "glintr100.onnx",
             "scrfd_10g_bnkps.onnx",
         ]:
-            if not os.path.exists(os.path.join(face_analysis, model)):
+            if not os.path.exists(os.path.join(face_analysis, 'models', model)):
                 logger.info(f"Downloading {model} to {face_analysis}")
                 os.system(
-                    f"wget -P {face_analysis} https://huggingface.co/memoavatar/memo/raw/main/misc/face_analysis/models/{model}"
+                    f"wget -O {face_analysis}/models/{model} https://huggingface.co/memoavatar/memo/resolve/main/misc/face_analysis/models/{model}?download=true"
                 )
+                # Check if the download was successful
+                if not os.path.exists(face_analysis):
+                    raise RuntimeError(f"Failed to download {model} to {face_analysis}")
+                # filesize
+                if os.path.getsize(face_analysis) < 1024*1024:
+                    raise RuntimeError(f"{face_analysis} file seems incorrect (too small), delete it and retry.")
         logger.info(f"Use face analysis models from {face_analysis}")
 
         vocal_separator = os.path.join(config.misc_model_dir, "misc/vocal_separator/Kim_Vocal_2.onnx")
@@ -87,7 +93,7 @@ def main():
             logger.info(f"Downloading vocal separator to {vocal_separator}")
             os.makedirs(os.path.dirname(vocal_separator), exist_ok=True)
             os.system(
-                f"wget -P {os.path.dirname(vocal_separator)} https://huggingface.co/memoavatar/memo/raw/main/misc/vocal_separator/Kim_Vocal_2.onnx"
+                f"wget -O {os.path.dirname(vocal_separator)}/Kim_Vocal_2.onnx https://huggingface.co/memoavatar/memo/resolve/main/misc/vocal_separator/Kim_Vocal_2.onnx?download=true"
             )
     else:
         logger.info(f"Loading manually specified model path: {config.model_name_or_path}")

--- a/inference.py
+++ b/inference.py
@@ -73,17 +73,18 @@ def main():
             "glintr100.onnx",
             "scrfd_10g_bnkps.onnx",
         ]:
-            if not os.path.exists(os.path.join(face_analysis, 'models', model)):
-                logger.info(f"Downloading {model} to {face_analysis}")
+            model_path = os.path.join(face_analysis, 'models', model)
+            if not os.path.exists(model_path):
+                logger.info(f"Downloading {model} to {face_analysis}/models")
                 os.system(
-                    f"wget -O {face_analysis}/models/{model} https://huggingface.co/memoavatar/memo/resolve/main/misc/face_analysis/models/{model}?download=true"
+                    f"wget -P {face_analysis}/models https://huggingface.co/memoavatar/memo/resolve/main/misc/face_analysis/models/{model}"
                 )
                 # Check if the download was successful
-                if not os.path.exists(face_analysis):
-                    raise RuntimeError(f"Failed to download {model} to {face_analysis}")
-                # filesize
-                if os.path.getsize(face_analysis) < 1024*1024:
-                    raise RuntimeError(f"{face_analysis} file seems incorrect (too small), delete it and retry.")
+                if not os.path.exists(model_path):
+                    raise RuntimeError(f"Failed to download {model} to {model_path}")
+                # File size check
+                if os.path.getsize(model_path) < 1024 * 1024:
+                    raise RuntimeError(f"{model_path} file seems incorrect (too small), delete it and retry.")
         logger.info(f"Use face analysis models from {face_analysis}")
 
         vocal_separator = os.path.join(config.misc_model_dir, "misc/vocal_separator/Kim_Vocal_2.onnx")
@@ -93,7 +94,7 @@ def main():
             logger.info(f"Downloading vocal separator to {vocal_separator}")
             os.makedirs(os.path.dirname(vocal_separator), exist_ok=True)
             os.system(
-                f"wget -O {os.path.dirname(vocal_separator)}/Kim_Vocal_2.onnx https://huggingface.co/memoavatar/memo/resolve/main/misc/vocal_separator/Kim_Vocal_2.onnx?download=true"
+                f"wget -P {os.path.dirname(vocal_separator)} https://huggingface.co/memoavatar/memo/resolve/main/misc/vocal_separator/Kim_Vocal_2.onnx"
             )
     else:
         logger.info(f"Loading manually specified model path: {config.model_name_or_path}")


### PR DESCRIPTION
Huggingface is now using LFS urls.
The current download of *.onnx files results in very small text files (< 1kiB) with LFS format.
This merge request fixes URL to add `?download=true` and force file name.
It also fix the file path because FaceAnalysis() was checking models in checkpoints/misc/face_analysis/models folder.